### PR TITLE
Add support for sequence-to-sequence models

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ from minicons import scorer
 
 mlm_model = scorer.MaskedLMScorer('bert-base-uncased', 'cpu')
 ilm_model = scorer.IncrementalLMScorer('distilgpt2', 'cpu')
+s2s_model = scorer.Seq2SeqScorer('t5-base', 'cpu')
 
 stimuli = ["The keys to the cabinet are on the table.",
            "The keys to the cabinet is on the table."]
@@ -69,6 +70,16 @@ print(ilm_model.sequence_score(stimuli, reduction = lambda x: -x.sum(0).item()))
 print(mlm_model.sequence_score(stimuli, reduction = lambda x: -x.sum(0).item()))
 '''
 [13.962685585021973, 23.415111541748047]
+'''
+
+# Seq2seq scoring
+## Blank source sequence, target sequence specified in `stimuli`
+print(s2s_model.sequence_score(stimuli, source_format = 'blank')
+## Source sequence is the same as the target sequence in `stimuli`
+print(s2s_model.sequence_score(stimuli, source_format = 'copy')
+'''
+[-7.910910129547119, -7.835635185241699]
+[-10.555519104003906, -9.532546997070312]
 '''
 ```
 

--- a/minicons/scorer.py
+++ b/minicons/scorer.py
@@ -2,7 +2,11 @@ from logging import log
 from typing import Iterable, Union, List, Dict, Optional, Callable, Tuple, Any
 
 import torch
-from transformers import AutoModelForCausalLM, AutoModelForMaskedLM, AutoTokenizer
+from transformers import (
+        AutoModelForCausalLM, AutoModelForMaskedLM,
+        AutoModelForSeq2SeqLM,
+        AutoTokenizer
+)
 from transformers.utils.logging import set_verbosity_error
 
 from collections import defaultdict
@@ -981,6 +985,401 @@ class IncrementalLMScorer(LMScorer):
         return res
 
     def logprobs(self, batch: Iterable, rank = False) -> Union[float, List[float]]:
+        """
+        Returns log probabilities
+
+        :param `Iterable` batch: A batch of inputs fit to pass to a
+            transformer LM.
+        :param rank: Specifies whether to also return ranks of words.
+        :type rank: bool
+
+        :return: List of LM score metrics (probability and rank)
+            and tokens.
+        :rtype: Union[List[Tuple[torch.Tensor, str]], List[Tuple[torch.Tensor, str, int]]]
+        """
+        warnings.warn(
+            "logprobs is deprecated, use compute_stats instead",
+            DeprecationWarning
+        )
+        batch, offsets = batch
+        ids = batch["input_ids"]
+        ids = ids.to(self.device)
+        attention_masks = batch["attention_mask"]
+        attention_masks = attention_masks.to(self.device)
+        nopad_mask = ids != self.tokenizer.pad_token_id
+
+        with torch.no_grad():
+            outputs = self.model(ids, attention_mask=attention_masks)
+            logits = outputs.logits
+            if self.device == 'cuda:0' or self.device == "cuda:1":
+                logits.detach()
+        
+        outputs = []
+        for sent_index in range(len(ids)):
+            sent_nopad_mask = nopad_mask[sent_index]
+            # len(tokens) = len(text[sent_index]) + 1
+            sent_tokens = [
+                tok
+                for i, tok in enumerate(batch.tokens(sent_index))
+                if sent_nopad_mask[i] and i > offsets[sent_index]
+            ]
+
+            # sent_ids.shape = [len(text[sent_index]) + 1]
+            # ignore first token (<|eos|>)
+            sent_ids = ids[sent_index, sent_nopad_mask][1:]
+            # logits.shape = [len(text[sent_index]) + 1, vocab_size]
+            sent_logits = logits[sent_index, sent_nopad_mask][:-1, :]
+            sent_logits[:, self.tokenizer.pad_token_id] = float("-inf")
+            # ids_scores.shape = [seq_len + 1]
+            # select only the ids present in the sentence out of all vocab items (as a 2d array)
+            sent_ids_scores = sent_logits.gather(1, sent_ids.unsqueeze(1)).squeeze(1)
+            # log_prob.shape = [seq_len + 1]
+            sent_log_probs = sent_ids_scores - sent_logits.logsumexp(1)
+            
+            sent_log_probs = sent_log_probs.type(torch.DoubleTensor)
+            sent_log_probs = sent_log_probs[offsets[sent_index]:]
+            lengths = len(sent_log_probs)
+            if rank:
+                shape = sent_logits.shape
+                inv_ranks = (sent_logits).argsort().argsort() + 1
+                ranks = shape[1] - inv_ranks + 1
+                word_ranks = ranks[list(range(shape[0]))[offsets[sent_index]:], sent_ids[offsets[sent_index]: ].tolist()].split(lengths)
+                word_ranks = [x[0] for x in word_ranks]
+                outputs.append((sent_log_probs, sent_tokens, word_ranks))
+            else:
+                outputs.append((sent_log_probs, sent_tokens))
+            # output = (sent_log_probs.sum(), sent_ids, sent_tokens)
+            # outputs.append(output)
+        return outputs
+
+
+class Seq2SeqScorer(LMScorer):
+    """
+    Class for Autoregressive or Incremental (or left-to-right) language models such as GPT2, etc.
+
+    :param model_name: name of the model, should either be a path
+        to a model (.pt or .bin file) stored locally, or a
+        pretrained model stored on the Huggingface Model Hub.
+    :type model_name: str
+    :param device: device type that the model should be loaded on,
+        options: `cpu or cuda:{0, 1, ...}`
+    :type device: str, optional
+    """
+    def __init__(self, model_name: str, device: Optional[str] = 'cpu') -> None:
+        """
+        :param model_name: name of the model, should either be a path
+            to a model (.pt or .bin file) stored locally, or a
+            pretrained model stored on the Huggingface Model Hub.
+
+        :type model_name: str
+        :param device: device type that the model should be loaded on,
+            options: `cpu or cuda:{0, 1, ...}`
+        :type device: str, optional
+        """
+        super(Seq2SeqScorer, self).__init__(model_name, device)
+        
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(
+                model_name, return_dict = True
+        )
+        
+        # define CLS and SEP tokens
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": ["<|pad|>"]})
+            self.tokenizer.pad_token = "<|pad|>"
+
+        if self.tokenizer.bos_token is None:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": ["<|bos|>"]})
+            self.tokenizer.bos_token = "<|bos|>"
+
+        self.model.resize_token_embeddings(len(self.tokenizer))
+        self.model.to(self.device)
+        self.model.eval()
+    
+    def add_special_tokens(self, text: Union[str, List[str]]) -> Union[str, List[str]]:
+        """
+        Reformats input text to add special model-dependent tokens.
+
+        :param text: single string or batch of strings to be
+            modified.
+        :type text: Union[str, List[str]]
+        
+        :return: Modified input, containing special tokens as per 
+            tokenizer specification
+        :rtype: Union[float, List[float]]:
+        """
+        sentences = [text] if isinstance(text, str) else text
+        sentences = [self.tokenizer.bos_token + sentence for sentence in sentences]
+
+        return sentences
+
+    def encode(self, text: Union[str, List[str]]) -> dict:
+        text = [text] if isinstance(text, str) else text
+        return self.tokenizer(text, return_tensors='pt', padding = True)
+    
+    def prepare_text(self, text: Union[str, List[str]]) -> Tuple:
+        """
+        Prepares a batch of input text into a format fit to run LM
+        scoring on. 
+
+        :param text: batch of sentences to be prepared for scoring.
+        
+        :return: Batch of formatted input that can be passed to
+            ``compute_stats``
+        """
+        encoded = self.encode(text)
+        offsets = [0] * len(encoded['input_ids'])
+        return encoded, offsets
+    
+    def prime_text(self, preamble: Union[str, List[str]], stimuli: Union[str, List[str]]) -> Tuple:
+        """
+        Prepares a batch of input text into a format fit to run LM
+        scoring on. 
+
+        :param ``Union[str, List[str]]`` preamble: Batch of prefixes/prime/preambles on which the LM is conditioned.
+        :param ``Union[str, List[str]]`` stimuli: Batch of continuations that are scored based on the conditioned text (provided in the ``preamble``). The positions of the elements match their counterparts in the ``preamble``.
+
+        :return: Batch of formatted input that can be passed to
+            ``compute_stats``
+        """
+        preamble_text = [preamble] if isinstance(preamble, str) else preamble
+        preamble_encoded = self.tokenizer(preamble_text)['input_ids']
+        preamble_lens = []
+        for preamble_tokens in preamble_encoded:
+            preamble_lens.append(len([token for token in preamble_tokens if token != self.tokenizer.pad_token_id and token != self.tokenizer.sep_token_id]) - 1)
+        
+        sentences = [preamble + " " + stimuli] if isinstance(preamble, str) else [p + " " + s for p , s in list(zip(preamble, stimuli))]
+            
+        return self.encode(sentences), preamble_lens
+    
+    def distribution(self, batch: Iterable) -> torch.Tensor:
+        """
+        Returns a distribution over the vocabulary of the model.
+
+        :param `Iterable` batch: A batch of inputs fit to pass to a
+            transformer LM.
+
+        :return: Tensor consisting of log probabilies over vocab items.
+        """
+        batch, offsets = batch
+        ids = batch["input_ids"]
+        ids = ids.to(self.device)
+        attention_masks = batch["attention_mask"]
+        attention_masks = attention_masks.to(self.device)
+        nopad_mask = ids != self.tokenizer.pad_token_id
+
+        with torch.no_grad():
+            outputs = self.model(ids, attention_mask=attention_masks)
+            logits = outputs.logits
+            if self.device == 'cuda:0' or self.device == "cuda:1":
+                logits.detach()
+
+        outputs = []
+        for sent_index in range(len(ids)):
+            sent_nopad_mask = nopad_mask[sent_index]
+            # len(tokens) = len(text[sent_index]) + 1
+            sent_tokens = [
+                tok
+                for i, tok in enumerate(batch.tokens(sent_index))
+                if sent_nopad_mask[i] and i > offsets[sent_index] + 1
+            ]
+
+            # sent_ids.shape = [len(text[sent_index]) + 1]
+            # ignore first token (<|eos|>)
+            sent_ids = ids[sent_index, sent_nopad_mask][1:]
+            # logits.shape = [len(text[sent_index]) + 1, vocab_size]
+            sent_logits = logits[sent_index, sent_nopad_mask][:-1, :]
+            sent_logits[:, self.tokenizer.pad_token_id] = float("-inf")
+
+            outputs.append(sent_logits[-1])
+        return torch.stack(outputs, 0)
+
+    def next_word_distribution(self, queries: List, surprisal: bool = False):
+        '''
+        Returns the log probability distribution of the next word.
+        '''
+        encoded = self.encode(queries)
+        encoded = encoded.to(self.device)
+        query_ids = [[j for j, i in enumerate(instance) if i != self.tokenizer.pad_token_id][-1] for instance in encoded['input_ids'].tolist()]
+
+        logits = self.model(**encoded).logits.detach()
+        logits[:, :, self.tokenizer.pad_token_id] = float("-inf")
+
+        logits = logits[torch.arange(len(query_ids)), query_ids]
+        logprobs = logits - logits.logsumexp(1).unsqueeze(1)
+
+        if surprisal:
+            logprobs = -1.0 * logprobs
+        
+        return logprobs
+
+    def compute_stats(self, batch: Iterable, source: Iterable, rank: bool = False, prob: bool = False, base_two: bool = False, return_tensors: bool = False) -> Union[Tuple[List[float], List[float]], List[float]]:
+        '''
+        Primary computational method that processes a batch of prepared sentences and returns per-token scores for each sentence. By default, returns log-probabilities.
+
+        :param ``Iterable`` batch: batched input as processed by ``prepare_text`` or ``prime_text``.
+        :param ``bool`` rank: whether the model should also return ranks per word (based on the conditional log-probability of the word in context).
+        :param ``bool`` prob: whether the model should return probabilities instead of log-probabilities. Can only be `True` when `base_two` is `False`.
+        :param ``bool`` base_two: whether the base of the log should be 2 (usually preferred when reporting results in bits). Can only be `True` when `prob` is `False`.
+        :param ``bool`` return_tensors: whether the model should return scores as a list of tensors instead of a list of lists. This is important in some other convenient methods used in the package.
+
+        :return: Either a tuple of lists, each containing probabilities and ranks per token in each sentence passed in the input.
+        :rtype: ``Union[Tuple[List[float], List[int]], List[float]]``
+        '''
+        assert not (base_two and prob), "cannot both use base (which is for a log), and a probability measure at the same time!"
+
+        source_encoded, source_offsets = source
+        target_encoded, target_offsets = batch
+        source_ids = source_encoded['input_ids'].to(self.device)
+        target_ids = target_encoded['input_ids'].to(self.device)
+        
+        source_ids_list = [[i for i in instance if i != self.tokenizer.pad_token_id] for instance in source_encoded['input_ids'].tolist()]
+        target_ids_list = [[i for i in instance if i != self.tokenizer.pad_token_id] for instance in target_encoded['input_ids'].tolist()]
+
+        ## Ignore the probabilities of the first token.
+        source_effective_ids = [id[1:] for id in source_ids_list]
+        target_effective_ids = [id[1:] for id in target_ids_list]
+
+        with torch.no_grad():
+            logits = self.model(input_ids=source_ids, labels=target_ids).logits.detach()
+
+        logits[:, :, self.tokenizer.pad_token_id] = float("-inf")
+
+        logits = logits.split([1]*len(target_offsets))
+
+        ## Set up storage variables
+        scores = []
+        if rank:
+            ranks = []
+
+        for logit, idx, offset in zip(logits, target_effective_ids, target_offsets):
+            length = len(idx)
+            logit = logit.squeeze(0)[:, :-1][torch.arange(offset, length),]
+
+            logprob_distribution = logit - logit.logsumexp(1).unsqueeze(1)
+            query_ids = idx[offset:]
+            if base_two:
+                '''
+                Log_2(X) = log_e(X)/log_e(2) (broadcasted)
+                '''
+                score = (logprob_distribution[torch.arange(length - offset), query_ids] / torch.tensor(2).log()).tolist()
+            else:
+                if prob:
+                    score = logprob_distribution[torch.arange(length - offset), query_ids].exp().tolist()
+                else:
+                    score = logprob_distribution[torch.arange(length - offset), query_ids].tolist()
+
+            if rank:
+                # shape = logprob_distribution.shape
+                '''
+                Double argsort trick:
+                first argsort returns idxes of values that would return a sorted tensor,
+                second argsort returns ranks (0 indexed)
+
+                Proof: https://www.berkayantmen.com/rank.html
+
+                TODO: Try to implement ranking in linear time but across arbitrary dimensions:
+                https://stackoverflow.com/a/5284703
+                '''
+                word_ranks = (-1.0 * logprob_distribution).argsort().argsort() + 1
+                # inv_ranks = logprob_distribution.argsort().argsort() + 1
+                # word_ranks = shape[1] - inv_ranks + 1
+                word_ranks = word_ranks[torch.arange(length - offset), query_ids].tolist()
+                ranks.append(word_ranks)
+
+            scores.append(score)
+
+        if return_tensors:
+            scores = [torch.tensor(l) for l in scores]
+
+        if rank:
+            return scores, ranks
+        else:
+            return scores
+
+    def sequence_score(self, batch, reduction = lambda x: x.mean(0).item(), base_two = False,
+                       source_format = 'blank'):
+        '''
+        TODO: reduction should be a string, if it's a function, specify what kind of function. --> how to ensure it is always that type?
+        '''
+        tokenized = self.prepare_text(batch)
+        if source_format == 'blank':
+            source = [""] * len(batch)
+        elif source_format == 'copy':
+            source = batch
+        source = self.prepare_text(source)
+
+        scores = self.compute_stats(tokenized, source, rank = False, base_two = base_two, return_tensors = True)
+        reduced = list(map(reduction, scores))
+        return reduced
+
+    def token_score(self, batch: Union[str, List[str]], surprisal: bool = False, prob: bool = False, base_two: bool = False, rank: bool = False, source_format: str = 'blank') -> Union[List[Tuple[str, float]], List[Tuple[str, float, int]]]:
+        '''
+        For every input sentence, returns a list of tuples in the following format:
+            `(token, score)`,
+
+        where score represents the log-probability (by default) of the token given context. Can also return ranks along with scores.
+
+        :param ``Union[str, List[str]]`` batch: a single sentence or a batch of sentences.
+        :param ``bool`` surprisal: If `True`, returns per-word surprisals instead of log-probabilities.
+        :param ``bool`` prob: If `True`, returns per-word probabilities instead of log-probabilities.
+        :param ``bool`` base_two: If `True`, uses log base 2 instead of natural-log (returns bits of values in case of surprisals)
+        :param ``bool`` rank: If `True`, also returns the rank of each word in context (based on the log-probability value)
+
+        :return: A `List` containing a `Tuple` consisting of the word, its associated score, and optionally, its rank.
+        :rtype: ``Union[List[Tuple[str, float]], List[Tuple[str, float, int]]]``
+        '''
+
+        assert not (surprisal and prob), "cannot both evaluate probability and surprisal at the same time!"
+        assert not (base_two and prob), "cannot both use base (which is for a log), and a probability measure at the same time!"
+
+        tokenized = self.prepare_text(batch)
+        if source_format == 'blank':
+            source = [""] * len(batch)
+        elif source_format == 'copy':
+            source = batch
+        source = self.prepare_text(source)
+
+        if rank:
+            scores, ranks = self.compute_stats(tokenized, source, rank = rank, prob = prob, base_two = base_two, return_tensors=True)
+        else:
+            scores = self.compute_stats(tokenized, source, prob = prob, base_two = base_two, return_tensors=True)
+
+        if surprisal:
+            scores = [-1.0 * s for s in scores]
+
+        scores = [s.tolist() for s in scores]
+
+        indices = [[i for i in indexed if i != self.tokenizer.pad_token_id] for indexed in tokenized[0]['input_ids'].tolist()]
+        tokens = [self.decode(idx) for idx in indices]
+
+        if rank:
+            assert len(tokens) == len(scores) == len(ranks)
+        else:
+            assert len(tokens) == len(scores)
+
+        res = []
+        if rank:
+            for t, s, r in zip(tokens, scores, ranks):
+                if len(t) > len(s):
+                    diff = len(t) - len(s)
+                    sc = [0.0]*diff + s
+                    ra = [0]*diff + r
+                    res.append(list(zip(t, sc, ra)))
+                else:
+                    res.append(list(zip(t, sc, ra)))
+            # return [list(zip(t, s, r)) for t, s, r in zip(tokens, scores, ranks)]
+        else:
+            for t, s in zip(tokens, scores):
+                if len(t) > len(s):
+                    diff = len(t) - len(s)
+                    sc = [0.0]*diff + s
+                    res.append(list(zip(t, sc)))
+                else:
+                    res.append(list(zip(t, sc)))
+
+        return res
+
+    def logprobs(self, batch: Iterable, rank = False, source_format: str = 'blank') -> Union[float, List[float]]:
         """
         Returns log probabilities
 


### PR DESCRIPTION
Added the `Seq2SeqScorer` class in `minicons/scorer.py`. Support for two source sequence formats: "blank" (no source sequence) and "copy" (source is the same as target).

Tested with T5. May not work as well with models which require separate source and target formats (e.g., BART).