### PR TITLE
fix a bug in IncrementalLMScorer

### DIFF
--- a/minicons/scorer.py
+++ b/minicons/scorer.py
@@ -1234,10 +1234,7 @@ class IncrementalLMScorer(LMScorer):
 
         for logit, idx, offset in zip(logits, effective_ids, offsets):
             length = len(idx)
-            if idx[-1] == self.tokenizer.eos_token_id:
-                logit = logit.squeeze(0)[torch.arange(offset, length),]
-            else:
-                logit = logit.squeeze(0)[:, :-1][torch.arange(offset, length),]
+            logit = logit.squeeze(0)[torch.arange(offset, length),]
 
             logprob_distribution = logit - logit.logsumexp(1).unsqueeze(1)
             query_ids = idx[offset:]


### PR DESCRIPTION
the bug occurs when the sequence does not end with eos token so that the logit in the last token in the vocab is removed.

The problem is, `logit.squeeze(0)` has only two dimensions and of size `(max_length, vocab_size)`. So `logit.squeeze(0)[:, :-1]` do not remove the logits on the last token but just shrink the vocabulary by removing the last token in the vocabulary. This is definitely unintended. Also, it doesn't matter if `idx[-1] == self.tokenizer.eos_token_id` (and the last token is removed) here, because `[torch.arange(offset, length),]` will have the same effect of subscription.

So the solution is to simply keep only the first clause.